### PR TITLE
feat: Add Docker Hub publishing to CI/CD

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,8 +8,10 @@ on:
     branches: [ main, master ]
 
 env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY_GHCR: ghcr.io
+  REGISTRY_DOCKER_HUB: docker.io
+  IMAGE_NAME_GHCR: ${{ github.repository }}
+  IMAGE_NAME_DOCKER_HUB: crispyfishtech/${{ github.event.repository.name }}
 
 jobs:
   build:
@@ -29,15 +31,25 @@ jobs:
       if: github.event_name != 'pull_request'
       uses: docker/login-action@v3
       with:
-        registry: ${{ env.REGISTRY }}
+        registry: ${{ env.REGISTRY_GHCR }}
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Log in to Docker Hub
+      if: github.event_name != 'pull_request'
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY_DOCKER_HUB }}
+        username: crispyfishtech
+        password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
     - name: Extract metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        images: |
+          ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
+          ${{ env.REGISTRY_DOCKER_HUB }}/${{ env.IMAGE_NAME_DOCKER_HUB }}
         tags: |
           type=ref,event=branch
           type=ref,event=pr


### PR DESCRIPTION

This PR enhances our CI/CD pipeline by adding the capability to publish Docker images to Docker Hub, in addition to the existing GitHub Container Registry.

Key Changes:
- Configured GitHub Actions workflow to log in to Docker Hub.
- Updated image tagging strategy to include Docker Hub (`crispyfishtech/crispyfish-demo`).
- Modified the build and push action to push images to both GitHub Container Registry and Docker Hub.

To enable Docker Hub publishing, ensure you have set the `DOCKER_HUB_TOKEN` secret in your repository settings with a valid Docker Hub access token.

This allows for wider distribution and easier access to our Docker images.
