### PR TITLE
feat: add crispyfish-demo environment to Docker workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,7 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment: crispyfish-demo
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR adds the 'crispyfish-demo' GitHub environment to the Docker build job. This allows the workflow to utilize environment-specific secrets and protection rules configured for this environment in the repository settings.