### PR TITLE
Upgrade GitHub Actions to Node 24 compatible versions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Container Registry
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY_GHCR }}
         username: ${{ github.actor }}
@@ -38,7 +38,7 @@ jobs:
 
     - name: Log in to Docker Hub
       if: github.event_name != 'pull_request'
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY_DOCKER_HUB }}
         username: crispyfishtech
@@ -46,7 +46,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: |
           ${{ env.REGISTRY_GHCR }}/${{ env.IMAGE_NAME_GHCR }}
@@ -59,7 +59,7 @@ jobs:
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
Upgraded the following actions to be Node 24 compatible:
- actions/checkout@v4 -> v5
- docker/setup-buildx-action@v3 -> v4
- docker/login-action@v3 -> v4
- docker/metadata-action@v5 -> v6