### PR TITLE
Fix Semantic Release Action Name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Semantic Release
-        uses: cyclyx/semantic-release-action@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        uses: cycjimmy/semantic-release-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+


### PR DESCRIPTION
Corrects the action repository name to cycjimmy/semantic-release-action@v6 as per documentation.