### PR TITLE
Fix Semantic Release Plugins

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -2,8 +2,9 @@
   "branches": ["main", "master"],
   "plugins": [
     "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
     [
-      "@semantic-release/release",
+      "@semantic-release/github",
       {
         "channels": ["stable"]
       }


### PR DESCRIPTION
Corrects the plugin names in .releaserc by replacing the invalid @semantic-release/release with @semantic-release/release-notes-generator and @semantic-release/github.