### PR TITLE
Fix Docker Tag Sequence

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Build and Push Docker Image
 
 on:
   push:
-    branches: [ main, master ]
     tags: [ 'v*' ]
   pull_request:
     branches: [ main, master ]


### PR DESCRIPTION
Removed 'push' to branches from docker.yml. Now it only triggers on tags, ensuring the semantic-release workflow creates the version tag before the Docker build starts. This ensures images are correctly tagged with semantic versions.