### PR TITLE
Use PAT Token for Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
 


### PR DESCRIPTION
Replaced GITHUB_TOKEN with PAT_TOKEN in the release workflow to allow the created Git tags to trigger downstream Docker build workflows.