### PR TITLE
Fix Semantic Release Token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,4 +22,5 @@ jobs:
         uses: cycjimmy/semantic-release-action@v6
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
 


### PR DESCRIPTION
Adds GH_TOKEN environment variable alongside GITHUB_TOKEN to ensure the semantic-release action can correctly authenticate using the PAT_TOKEN secret.