### PR TITLE
Fix Semantic Release Trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v6

--- a/.releaserc
+++ b/.releaserc
@@ -4,13 +4,6 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     [
-      "@semantic-release/git",
-      {
-        "assets": ["package.json", "CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [no ci]"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "channels": ["stable"]

--- a/.releaserc
+++ b/.releaserc
@@ -4,6 +4,13 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     [
+      "@semantic-release/git",
+      {
+        "assets": ["package.json", "CHANGELOG.md"],
+        "message": "chore(release): ${nextRelease.version} [no ci]"
+      }
+    ],
+    [
       "@semantic-release/github",
       {
         "channels": ["stable"]


### PR DESCRIPTION
Implements critical fixes to ensure tag pushes trigger downstream Docker workflows:
1. Sets persist-credentials: false in checkout to prevent PAT overwrite.
2. Adds @semantic-release/git plugin with a custom message to avoid [skip ci] blocks.